### PR TITLE
Implement assignment sorting in Verilog output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+btor2verilog
+deps/
+
+
 # Prerequisites
 *.d
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 btor2verilog
 deps/
+.vscode/
+yosys/
 
 
 # Prerequisites

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-debug: _DEBUG=-g
+debug: _DEBUG=-g -Wall
 debug: btor2verilog
 
 btor2verilog: main.cpp btor2verilog.cpp

--- a/btor2verilog.cpp
+++ b/btor2verilog.cpp
@@ -471,7 +471,7 @@ std::string Btor2Verilog::get_full_select(size_t width) const
   return "[" + std::to_string(width-1) + ":0]";
 }
 
-vector<size_t> sort_input_output(unordered_set<size_t> &_a)
+vector<size_t> Btor2Verilog::sort_input_output(unordered_set<size_t> &_a)
 {
   vector<size_t>a_sorted;
   a_sorted.assign(_a.begin(), _a.end());
@@ -479,7 +479,7 @@ vector<size_t> sort_input_output(unordered_set<size_t> &_a)
   return a_sorted;
 }
 
-vector<string> sort_assertions_assumes(const vector<string> &_a)
+vector<string> Btor2Verilog::sort_assertions_assumes(const vector<string> &_a)
 {
   vector<string> a_sorted;
   a_sorted.assign(_a.begin(),_a.end());
@@ -509,7 +509,7 @@ vector<string> sort_assertions_assumes(const vector<string> &_a)
 }
 
 //srot combinational assignment and state updates
-vector<vector<string>> sort_assignment(const std::unordered_map<std::string, std::string> 
+vector<vector<string>> Btor2Verilog::sort_assignment(const unordered_map<string, string> 
                                     & _assigns_)
 {
   vector<vector<string>>assigns_sorted;

--- a/btor2verilog.cpp
+++ b/btor2verilog.cpp
@@ -566,10 +566,8 @@ bool Btor2Verilog::gen_verilog()
   verilog_ += "\n);\n\n\t// states\n";
 
 
-  vector<size_t> states_sorted;
-  states_sorted.assign(states_.begin(),states_.end());
 
-  for (auto st : states_sorted)
+  for (auto st : states_)  //already sorted
   {
     s = sorts_.at(st);
     if (s.k == array_k)

--- a/btor2verilog.cpp
+++ b/btor2verilog.cpp
@@ -482,13 +482,22 @@ vector<vector<string>> sort_wire_assignment(std::unordered_map<std::string, std:
                                     & wire_assigns_)
 {
   vector<vector<string>>wire_assigns_sorted;
-  for(const auto elem : wire_assigns_)
+  for(const auto &elem : wire_assigns_)
   {
     wire_assigns_sorted.push_back({elem.first, elem.second});
   }
   sort(wire_assigns_sorted.begin(), wire_assigns_sorted.end(), [](const vector<string> &a, const vector<string> &b) {
-        return a[0].compare(b[0]);
-    }
+        if(a[0][0] == 'w' && b[0][0] == 'o')
+          return true;
+        else if(a[0][0] == 'o' && b[0][0] == 'w')
+          return false;
+        else       
+        {
+          int a_num = stoi(a[0].substr(1));
+          int b_num = stoi(b[0].substr(1));
+          return a_num < b_num;
+        }
+  }
     );
   return wire_assigns_sorted;
 }
@@ -578,7 +587,7 @@ bool Btor2Verilog::gen_verilog()
   }
 
   verilog_ += "\n\t// assignments\n";
-  for (const auto elem : sort_wire_assignment(wire_assigns_)) //wire_assigns_ should be sorted 
+  for (const auto &elem : sort_wire_assignment(wire_assigns_)) //wire_assigns_ should be sorted 
   {
     verilog_ += "\tassign " + elem[0] + " = " + elem[1] + ";\n";
   }

--- a/btor2verilog.h
+++ b/btor2verilog.h
@@ -43,6 +43,11 @@ namespace btor2verilog
     bool combinational_assignment();
     std::string get_full_select(size_t width) const;
 
+    std::vector<std::string> sort_assertions_assumes(const std::vector<std::string> &_a);
+    std::vector<std::vector<std::string>> sort_assignment(
+          const std::unordered_map<std::string, std::string> & _assigns_);
+    std::vector<size_t> sort_input_output(std::unordered_set<size_t> &_a);
+
     std::string err_;
     std::string verilog_;
 


### PR DESCRIPTION
This PR addresses the suggestion from issue #2 by implementing sorting for assignments in the Verilog output. 

## Changes:
- **Added fucntions to sort assignments**.
- Updated the `.gitignore` file to exclude more unnecessary files.
- Added the `-Wall` option to the compilation flags to enable all compiler warnings.